### PR TITLE
Bug 964314 - Prevent SoundCloud failed searches from crashing server

### DIFF
--- a/lib/services/soundcloud.js
+++ b/lib/services/soundcloud.js
@@ -29,6 +29,10 @@ module.exports = function( options, callback ) {
       return callback( err );
     }
 
+    if ( !Array.isArray( body ) ) {
+      return callback( "[webmaker-mediasync]: No data successfully retrieved." );
+    }
+
     var oldObj,
         dataArray = [],
         tempObj;
@@ -59,6 +63,12 @@ module.exports = function( options, callback ) {
 
       if ( err ) {
         return callback( err );
+      }
+
+      // If this request failed rather than bailing use the current data array for reported
+      // length
+      if ( !Array.isArray( body ) ) {
+        body = dataArray;
       }
 
       // SoundCloud has no concept of a total. For now, we cap the total results at 200.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=964314
